### PR TITLE
docs: add ARCHITECTURE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Use this file as the local operating guide when modifying `kaefa`.
 For every change, run what is relevant to the touched files:
 
 - Markdown docs: `npx -y markdownlint-cli2@0.11.0 <files...>`
+  (requires Node.js and npm)
 - R package checks: required GitHub checks on PR (`R-CMD-check`, `CodeQL`,
   `dependency-review`)
 - Targeted local validation for touched package behavior when applicable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,7 @@ For every change, run what is relevant to the touched files:
 - Markdown docs: `npx -y markdownlint-cli2@0.20.0 <files...>`
   (requires Node.js and npm)
 - R package checks: required GitHub checks on PR (`R-CMD-check`,
-  `dependency-review`, and `CodeQL` when enabled by repository code scanning
-  setup)
+  `dependency-review`)
 - Targeted local validation for touched package behavior when applicable
 
 ### Optional R Code Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,18 @@ Use this file as the local operating guide when modifying `kaefa`.
 
 For every change, run what is relevant to the touched files:
 
-- Markdown docs: `npx -y markdownlint-cli2@0.11.0 <files...>`
+- Markdown docs: `npx -y markdownlint-cli2@0.20.0 <files...>`
   (requires Node.js and npm)
-- R package checks: required GitHub checks on PR (`R-CMD-check`, `CodeQL`,
-  `dependency-review`)
+- R package checks: required GitHub checks on PR (`R-CMD-check`,
+  `dependency-review`, and `CodeQL` when enabled by repository code scanning
+  setup)
 - Targeted local validation for touched package behavior when applicable
+
+### Optional R Code Validation
+
+- Style lint (optional): run `lintr` on changed R files.
+- Shiny smoke run (optional): launch `launchAEFA()` for UI-touching changes.
+- Tests (optional): run `devtools::test()` or targeted `testthat` files.
 
 ## Review and Merge
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+Repository guidance for human and AI contributors.
+
+## Scope
+
+Use this file as the local operating guide when modifying `kaefa`.
+
+## Key Paths
+
+- Core orchestration: `R/kaefa.R`
+- Estimation engine: `R/newEngine.R`
+- Shared helpers: `R/utils.R`
+- Shiny app: `inst/shiny-app/app.R`
+- Tests: `tests/testthat/`
+- CI and security gates: `.github/workflows/`
+
+## Working Rules
+
+1. Keep external behavior stable unless an issue/PR explicitly changes it.
+2. Prefer minimal, targeted edits over broad refactors.
+3. If docs are generated (`README.Rmd` -> `README.md`), regenerate in the same
+   commit when source docs change.
+4. Never commit secrets (`.env`, keys, tokens, credentials).
+
+## Verification Checklist
+
+For every change, run what is relevant to the touched files:
+
+- Markdown docs: `npx -y markdownlint-cli2@0.11.0 <files...>`
+- R package checks: required GitHub checks on PR (`R-CMD-check`, `CodeQL`,
+  `dependency-review`)
+- Targeted local validation for touched package behavior when applicable
+
+## Review and Merge
+
+- Resolve all review threads.
+- Ensure required checks are green.
+- Obtain approval before merge.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,50 @@
+# kaefa Architecture
+
+Last updated: 2026-02-14
+
+## Purpose
+
+`kaefa` is an R package for automated exploratory factor analysis (AEFA).
+It provides:
+
+- core AEFA execution (`aefa`, `engineAEFA`),
+- optional remote worker initialization (`aefaInit`),
+- an interactive Shiny UI (`launchAEFA`).
+
+## Repository Layout
+
+- `R/kaefa.R`: public orchestration entry points and exported runtime behavior.
+- `R/newEngine.R`: candidate-model estimation engine used by the AEFA loop.
+- `R/utils.R`: helper routines and shared utilities.
+- `inst/shiny-app/app.R`: bundled Shiny interface logic.
+- `inst/shiny-app/README.md`: Shiny usage and minimal UI configuration guide.
+- `tests/testthat/*.R`: functional, regression, and integration tests.
+- `.github/workflows/R-CMD-check.yaml`: required multi-OS package checks.
+- `.github/workflows/dependency-review.yml`: dependency risk gate.
+- `.github/workflows/codeql.yml`: code scanning / code quality analysis.
+- `README.Rmd` -> `README.md`: source and generated top-level documentation.
+
+## Runtime Flow
+
+1. User calls `aefa()` or launches `launchAEFA()`.
+2. `aefa()` coordinates iterative model search and candidate evaluation.
+3. `engineAEFA()` performs lower-level model estimation for each candidate.
+4. Best model is selected by configured information criteria and returned.
+5. Optional history/diagnostics are exposed when enabled.
+
+## Optional Remote Execution
+
+- `aefaInit()` configures worker hosts and SSH key paths.
+- Remote usage is optional; local execution is the default path.
+- Security-sensitive values (keys/tokens) must remain out of git history.
+
+## Quality and Security Gates
+
+- PR merge requires review approval and resolved conversations.
+- Required checks include R-CMD-check matrix, dependency review, and CodeQL.
+- Code scanning alerts are tracked via GitHub code scanning APIs.
+
+## Change Rule
+
+When architecture-level behavior changes (entry points, runtime flow, or CI
+gates), update this document in the same change set.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,6 @@ It provides:
 - `tests/testthat/*.R`: functional, regression, and integration tests.
 - `.github/workflows/R-CMD-check.yaml`: required multi-OS package checks.
 - `.github/workflows/dependency-review.yml`: dependency risk gate.
-- `.github/workflows/codeql.yml`: code scanning / code quality analysis.
 - `README.Rmd` -> `README.md`: source and generated top-level documentation.
 
 ## Runtime Flow
@@ -41,8 +40,9 @@ It provides:
 ## Quality and Security Gates
 
 - PR merge requires review approval and resolved conversations.
-- Required checks include R-CMD-check matrix, dependency review, and CodeQL.
-- Code scanning alerts are tracked via GitHub code scanning APIs.
+- Required checks include R-CMD-check matrix and dependency review.
+- If code scanning is enabled later, alerts can be tracked via GitHub code
+  scanning APIs.
 
 ## Change Rule
 


### PR DESCRIPTION
## Summary
- add a root `ARCHITECTURE.md` that documents repository structure, runtime flow, and CI/security gates
- add a root `AGENTS.md` with contributor operating rules and verification checklist
- align issue request for architecture docs and agent guidance

Closes #47