### PR TITLE
ci: pin R workflows to jammy to fix the noble stringfish TBB ABI failure

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,12 +20,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Ubuntu jobs pin to jammy (22.04): noble (24.04) ubuntu-latest
+        # source-builds the mirt -> ... -> stringfish chain, whose
+        # stringfish.so then fails to load with an Intel TBB ABI mismatch
+        # (undefined symbol tbb::...concurrent_vector_base_v3::internal_grow_by).
+        # P3M ships jammy binaries that avoid the source compile. Same pin as
+        # test-suite.yaml/test-fast.yaml and aFIPC's r.yml; revisit once P3M
+        # ships noble binaries. macOS/Windows are unaffected.
         config:
           - {os: macos-latest, r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'oldrel-1'}
+          - {os: ubuntu-22.04, r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-22.04, r: 'release'}
+          - {os: ubuntu-22.04, r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -11,7 +11,12 @@ permissions:
 
 jobs:
   test-fast:
-    runs-on: ubuntu-latest
+    # Pin to jammy (22.04): noble (24.04) ubuntu-latest source-builds the
+    # mirt -> ... -> stringfish chain, whose stringfish.so then fails to load
+    # with an Intel TBB ABI mismatch, aborting `R CMD INSTALL .`. P3M ships
+    # jammy binaries that avoid the source compile. Same pin as test-suite.yaml
+    # and aFIPC's r.yml; revisit once P3M ships noble binaries.
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -21,7 +21,16 @@ permissions:
 
 jobs:
   test-suite:
-    runs-on: ubuntu-latest
+    # Pin to jammy (22.04): Posit P3M ships precompiled Linux binaries for the
+    # current R release on jammy, but not for noble (24.04, today's
+    # ubuntu-latest). On noble, setup-r-dependencies source-builds the
+    # mirt -> SimDesign -> qs -> stringfish chain, and the source-built
+    # stringfish.so fails to load with an Intel TBB ABI mismatch (undefined
+    # symbol tbb::internal::concurrent_vector_base_v3::internal_grow_by),
+    # aborting `R CMD INSTALL .` / `library(kaefa)` before the suite can run.
+    # Jammy binaries avoid the source compile entirely; same pin as aFIPC's
+    # r.yml. Revisit once P3M ships noble binaries for this chain.
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
 
     env:


### PR DESCRIPTION
## Problem

The scheduled **`test-suite`** workflow is failing on `develop` ([run 30790869383](https://github.com/ContextualWisdomLab/kaefa/actions/runs/30790869383), head `76a853a`). `R CMD INSTALL .` aborts at package load:

```
unable to load shared object '.../stringfish/libs/stringfish.so':
  undefined symbol:
  _ZN3tbb8internal25concurrent_vector_base_v316internal_grow_byEmmPFvPvPKvmES4_
ERROR: lazy loading failed for package 'kaefa'
```

`ubuntu-latest` is now **noble (24.04)**, for which Posit P3M does **not** ship precompiled binaries for the `mirt → SimDesign → qs → stringfish` chain — so `setup-r-dependencies` source-builds `stringfish`, and the source-built `stringfish.so` links against a system Intel TBB whose ABI omits the expected symbol. Every load of `kaefa` (which imports `mirt`) then fails before any test runs.

`R-CMD-check` and `test-fast` only appear green because their last runs (2026-07-13) predate the noble switch; they load the package the same way and would fail identically on noble — including on this PR.

## Fix

Pin all three workflows' Ubuntu runners to **`ubuntu-22.04`** (jammy), whose P3M binaries avoid the source compile entirely. This is the **same remedy aFIPC's `r.yml` already uses** for this exact symbol. macOS/Windows `R-CMD-check` jobs are unchanged.

- `test-suite.yaml` → `ubuntu-22.04`
- `test-fast.yaml` → `ubuntu-22.04`
- `R-CMD-check.yaml` → the three Ubuntu matrix entries (devel/release/oldrel-1) → `ubuntu-22.04`

## Safety / validation

Workflow-runner change only — no package code, tests, or dependencies touched (YAML validated). The failing install is a noble-only condition that cannot be reproduced off-noble, so verification is by CI itself: this PR's runs execute on jammy, where the install/load succeeds. The pin is a proven fix for the identical symbol in a sibling repo. Comment in each file notes to revisit once P3M ships noble binaries for this chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzUnTqFnQqhRbaopvDdag7)_