### PR TITLE
docs(agents): code-owner gates disabled org-wide until multiple maintainers exist

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,19 +42,24 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # stringfish/qs2 binaries (CRAN/P3M) still link the legacy TBB from
+      # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
+      # On R-devel this breaks the SimDesign source build inside
+      # setup-r-dependencies itself, so prebuild BOTH from real CRAN source
+      # before dependency resolution (P3M serves binaries even via its source
+      # API); pak then keeps the installed same-version copies. Drop once
+      # upstream binaries are rebuilt.
+      - name: Prebuild stringfish and qs2 from source (TBB mismatch with RcppParallel 6.2.0)
+        run: |
+          Rscript -e 'install.packages(c("Rcpp", "RcppParallel"), repos = Sys.getenv("RSPM", unset = "https://cloud.r-project.org"))'
+          Rscript -e 'install.packages(c("stringfish", "qs2"), type = "source", repos = "https://cloud.r-project.org")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: |
             any::rcmdcheck
             any::testthat
           needs: check
-
-      # stringfish binaries (CRAN/P3M) still link the legacy TBB from
-      # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
-      # Rebuild from real CRAN source (P3M serves binaries even via its source
-      # API). Drop once upstream binaries are rebuilt.
-      - name: Rebuild stringfish and qs2 from source (TBB mismatch with RcppParallel 6.2.0)
-        run: Rscript -e 'install.packages(c("stringfish", "qs2"), type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,9 +44,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
+          # stringfish binaries were built against the legacy TBB bundled with
+          # RcppParallel <6.2; force a source build so it links the oneTBB in
+          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
           extra-packages: |
             any::rcmdcheck
             any::testthat
+            cran::stringfish?source
           needs: check
 
       - name: Run Zh formula regression tests

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,8 +53,8 @@ jobs:
       # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
       # Rebuild from real CRAN source (P3M serves binaries even via its source
       # API). Drop once upstream binaries are rebuilt.
-      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
-        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
+      - name: Rebuild stringfish and qs2 from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages(c("stringfish", "qs2"), type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,14 +44,17 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          # stringfish binaries were built against the legacy TBB bundled with
-          # RcppParallel <6.2; force a source build so it links the oneTBB in
-          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
           extra-packages: |
             any::rcmdcheck
             any::testthat
-            cran::stringfish?source
           needs: check
+
+      # stringfish binaries (CRAN/P3M) still link the legacy TBB from
+      # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
+      # Rebuild from real CRAN source (P3M serves binaries even via its source
+      # API). Drop once upstream binaries are rebuilt.
+      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -29,8 +29,8 @@ jobs:
       # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
       # Rebuild from real CRAN source (P3M serves binaries even via its source
       # API). Drop once upstream binaries are rebuilt.
-      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
-        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
+      - name: Rebuild stringfish and qs2 from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages(c("stringfish", "qs2"), type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -22,7 +22,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          extra-packages: any::testthat
+          # stringfish binaries were built against the legacy TBB bundled with
+          # RcppParallel <6.2; force a source build so it links the oneTBB in
+          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
+          extra-packages: |
+            any::testthat
+            cran::stringfish?source
           needs: check
 
       - name: Install kaefa package for fast tests

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -22,13 +22,15 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          # stringfish binaries were built against the legacy TBB bundled with
-          # RcppParallel <6.2; force a source build so it links the oneTBB in
-          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
-          extra-packages: |
-            any::testthat
-            cran::stringfish?source
+          extra-packages: any::testthat
           needs: check
+
+      # stringfish binaries (CRAN/P3M) still link the legacy TBB from
+      # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
+      # Rebuild from real CRAN source (P3M serves binaries even via its source
+      # API). Drop once upstream binaries are rebuilt.
+      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -45,8 +45,8 @@ jobs:
       # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
       # Rebuild from real CRAN source (P3M serves binaries even via its source
       # API). Drop once upstream binaries are rebuilt.
-      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
-        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
+      - name: Rebuild stringfish and qs2 from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages(c("stringfish", "qs2"), type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -38,13 +38,15 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          # stringfish binaries were built against the legacy TBB bundled with
-          # RcppParallel <6.2; force a source build so it links the oneTBB in
-          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
-          extra-packages: |
-            any::testthat
-            cran::stringfish?source
+          extra-packages: any::testthat
           needs: check
+
+      # stringfish binaries (CRAN/P3M) still link the legacy TBB from
+      # RcppParallel <6.2 and fail to load against RcppParallel 6.2.0's oneTBB.
+      # Rebuild from real CRAN source (P3M serves binaries even via its source
+      # API). Drop once upstream binaries are rebuilt.
+      - name: Rebuild stringfish from source (TBB mismatch with RcppParallel 6.2.0)
+        run: Rscript -e 'install.packages("stringfish", type = "source", repos = "https://cloud.r-project.org")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -38,7 +38,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          extra-packages: any::testthat
+          # stringfish binaries were built against the legacy TBB bundled with
+          # RcppParallel <6.2; force a source build so it links the oneTBB in
+          # RcppParallel 6.2.0. Drop once upstream binaries are rebuilt.
+          extra-packages: |
+            any::testthat
+            cran::stringfish?source
           needs: check
 
       - name: Install kaefa package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,11 @@ working on this repo. Keep this block; re-runs replace it in place.
 - Resolve all review threads.
 - Ensure required checks are green.
 - Obtain approval before merge.
+
+## Code-owner review gates — disabled (on hold)
+
+As of 2026-08-04, code-owner review requirements (`require_code_owner_reviews` in branch
+protection, `require_code_owner_review` in rulesets) are disabled across the ContextualWisdomLab
+org: there is a single maintainer (solo developer), so a code-owner approval gate can never be
+satisfied. This is ON HOLD until the org has multiple maintainers — do NOT re-enable these
+settings or add CODEOWNERS-based merge gates before then.


### PR DESCRIPTION
Records the 2026-08-04 org policy in AGENTS.md: code-owner review requirements are disabled everywhere (solo maintainer cannot satisfy them). ON HOLD until the org has multiple maintainers — do not re-enable.