### PR TITLE
ci: build qs2/stringfish from source (RcppParallel 6.2.0 oneTBB ABI break)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,9 +44,16 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
+          # ponytail: RcppParallel 6.2.0 (oneTBB) broke the ABI of prebuilt
+          # qs2/stringfish binaries (undefined tbb::internal symbols). Build both
+          # from source and bust the package cache; drop these two refs and
+          # cache-version once CRAN/PPM binaries are rebuilt against 6.2.0.
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             any::testthat
+            stringfish=?source
+            qs2=?source
           needs: check
 
       - name: Run Zh formula regression tests

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -22,7 +22,15 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          extra-packages: any::testthat
+          # ponytail: RcppParallel 6.2.0 (oneTBB) broke the ABI of prebuilt
+          # qs2/stringfish binaries (undefined tbb::internal symbols). Build both
+          # from source and bust the package cache; drop these two refs and
+          # cache-version once CRAN/PPM binaries are rebuilt against 6.2.0.
+          cache-version: 2
+          extra-packages: |
+            any::testthat
+            stringfish=?source
+            qs2=?source
           needs: check
 
       - name: Install kaefa package for fast tests

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -38,7 +38,15 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
-          extra-packages: any::testthat
+          # ponytail: RcppParallel 6.2.0 (oneTBB) broke the ABI of prebuilt
+          # qs2/stringfish binaries (undefined tbb::internal symbols). Build both
+          # from source and bust the package cache; drop these two refs and
+          # cache-version once CRAN/PPM binaries are rebuilt against 6.2.0.
+          cache-version: 2
+          extra-packages: |
+            any::testthat
+            stringfish=?source
+            qs2=?source
           needs: check
 
       - name: Install kaefa package


### PR DESCRIPTION
Since ~2026-08-01, every kaefa CI run fails at package load on all platforms:

```
unable to load shared object '.../stringfish/libs/stringfish.so':
undefined symbol: _ZN3tbb8internal25concurrent_vector_base_v316internal_grow_byEmmPFvPvPKvmES4_
```

**Root cause**: RcppParallel 6.2.0 migrated to oneTBB and dropped the legacy `tbb::internal` symbols. The prebuilt CRAN/PPM binaries of `qs2` and `stringfish` (pulled transitively via mirt → SimDesign → qs2) still link those symbols, and restored package caches carry the stale builds. Confirmed identical failures on macOS (`Symbol not found: __ZN3tbb8internal12NFS_AllocateEmmPv`), Windows (`LoadLibrary failure: The specified procedure could not be found`), and Ubuntu — pre-existing on all recent PR branches (e.g. runs 30878110721, 30876579843), unrelated to their diffs.

**Fix**: in all three workflows' `setup-r-dependencies`, force `stringfish=?source` and `qs2=?source` so they compile against the current RcppParallel, and bump `cache-version` to 2 to discard the poisoned caches. Revert both once CRAN/PPM rebuild the binaries against RcppParallel 6.2.0.

Unblocks #74 and every other open kaefa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)