### PR TITLE
ci: fix mac/windows R-CMD-check — rebuild stringfish against installed RcppParallel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,11 +49,12 @@ jobs:
             any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update (undefined tbb::internal symbols, all platforms). Rebuild from
-      # source so it links the installed RcppParallel. Drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,10 +50,9 @@ jobs:
           needs: check
 
       # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update (Symbol not found: tbb::internal::NFS_Allocate). Rebuild from
+      # oneTBB update (undefined tbb::internal symbols, all platforms). Rebuild from
       # source so it links the installed RcppParallel. Drop once upstream binaries sync.
       - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        if: runner.os != 'Linux'
         run: Rscript -e 'install.packages("stringfish", type = "source")'
 
       - name: Run Zh formula regression tests

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,6 +49,13 @@ jobs:
             any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update (Symbol not found: tbb::internal::NFS_Allocate). Rebuild from
+      # source so it links the installed RcppParallel. Drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        if: runner.os != 'Linux'
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Run Zh formula regression tests
         run: |
           Rscript -e 'install.packages(".", repos = NULL, type = "source")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,8 +45,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -61,8 +65,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,12 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: |
@@ -54,7 +60,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -25,10 +25,12 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -20,6 +20,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: any::testthat
@@ -30,7 +36,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -23,8 +23,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -37,8 +41,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -25,6 +25,11 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -39,8 +39,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -53,8 +57,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -41,10 +41,12 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -36,6 +36,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: any::testthat
@@ -46,7 +52,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -41,6 +41,11 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Install kaefa package
         run: R CMD INSTALL .
 


### PR DESCRIPTION
All non-ubuntu `R-CMD-check` jobs — and on some snapshots the ubuntu jobs, `test-fast`, and `test-suite` — fail on every PR: loading `kaefa` dies because prebuilt CRAN/RSPM binaries that link `RcppParallel`'s TBB were built before its oneTBB migration, which removed the legacy `tbb::internal`/`tbb::task` symbols:

```
stringfish.so: Symbol not found: __ZN3tbb8internal12NFS_AllocateEmmPv          (macOS)
stringfish.so: undefined symbol: _ZN3tbb8internal25concurrent_vector_base_...  (ubuntu)
qs2.so:        Symbol not found: __ZN3tbb4task13note_affinityEt                (macOS, after fixing stringfish)
```

It's upstream binary skew, not a code regression — develop last ran green 2026-07-13.

Fix: one step after `setup-r-dependencies` in each of the three workflows that rebuilds every installed package `LinkingTo` RcppParallel from source (`tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo")`), so they all link the RcppParallel actually installed. Package-agnostic on purpose — the first attempt patched only `stringfish` and `qs2` promptly failed the same way. Marked for removal once CRAN/RSPM binaries re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 다양한 환경에서 패키지 설치와 빌드 검증이 보다 안정적으로 수행되도록 자동화된 검사 절차를 개선했습니다.
  * 관련 패키지를 소스에서 다시 빌드하는 검증 단계를 추가해 호환성 문제를 조기에 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->