### PR TITLE
chore(ci): consolidate r-lib actions v2.12.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,13 +36,13 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
-      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: |
             any::rcmdcheck
@@ -54,7 +54,7 @@ jobs:
           Rscript -e 'install.packages(".", repos = NULL, type = "source")'
           Rscript -e 'library(kaefa); testthat::test_file("tests/testthat/test-zh-misfit-decision-rule.R")'
 
-      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           error-on: '"error"'
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
+          # Refresh the dependency cache after the macOS qs2/RcppParallel TBB ABI mismatch.
+          cache-version: '2'
           extra-packages: |
             any::rcmdcheck
             any::testthat

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,11 +49,12 @@ jobs:
             any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update (undefined tbb::internal symbols, all platforms). Rebuild from
-      # source so it links the installed RcppParallel. Drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,10 +50,9 @@ jobs:
           needs: check
 
       # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update (Symbol not found: tbb::internal::NFS_Allocate). Rebuild from
+      # oneTBB update (undefined tbb::internal symbols, all platforms). Rebuild from
       # source so it links the installed RcppParallel. Drop once upstream binaries sync.
       - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        if: runner.os != 'Linux'
         run: Rscript -e 'install.packages("stringfish", type = "source")'
 
       - name: Run Zh formula regression tests

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,6 +49,13 @@ jobs:
             any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update (Symbol not found: tbb::internal::NFS_Allocate). Rebuild from
+      # source so it links the installed RcppParallel. Drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        if: runner.os != 'Linux'
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Run Zh formula regression tests
         run: |
           Rscript -e 'install.packages(".", repos = NULL, type = "source")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,8 +45,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -61,8 +65,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,12 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: |
@@ -54,7 +60,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Run Zh formula regression tests
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,6 +51,10 @@ jobs:
             any::testthat
           needs: check
 
+      - name: Rebuild macOS TBB dependents from source
+        if: runner.os == 'macOS'
+        run: Rscript -e 'install.packages(c("RcppParallel", "qs2"), repos = "https://cloud.r-project.org", type = "source")'
+
       - name: Run Zh formula regression tests
         run: |
           Rscript -e 'install.packages(".", repos = NULL, type = "source")'

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -25,10 +25,12 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -20,6 +20,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: any::testthat
@@ -30,7 +36,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::testthat
           needs: check

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -23,8 +23,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -37,8 +41,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .

--- a/.github/workflows/test-fast.yaml
+++ b/.github/workflows/test-fast.yaml
@@ -25,6 +25,11 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Install kaefa package for fast tests
         run: R CMD INSTALL .
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -39,8 +39,12 @@ jobs:
       # ponytail: source-build stringfish BEFORE dependency setup — packages built
       # from source during install (e.g. SimDesign) load it at build time and die
       # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      # repos= must be a real source repo: RSPM serves prebuilt Linux binaries via
+      # source-style URLs, so type="source" against RSPM does NOT recompile.
       - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+        run: >-
+          Rscript -e 'install.packages(c("RcppParallel", "stringfish"), type = "source",
+          repos = "https://cloud.r-project.org")'
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
@@ -53,8 +57,9 @@ jobs:
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
         run: >-
-          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
-          if (length(bad)) install.packages(bad, type = "source")'
+          Rscript -e 'r <- "https://cloud.r-project.org"; install.packages("RcppParallel", type = "source", repos = r);
+          bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source", repos = r)'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -41,10 +41,12 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
-      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
-      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
-      - name: Rebuild stringfish from source (RcppParallel ABI skew)
-        run: Rscript -e 'install.packages("stringfish", type = "source")'
+      # ponytail: CRAN/RSPM binary skew — prebuilt binaries (stringfish, qs2, ...) lag
+      # RcppParallel's oneTBB update (undefined tbb::internal / tbb::task symbols).
+      # Rebuild everything LinkingTo RcppParallel from source so it links the installed
+      # copy. Drop once upstream binaries re-sync.
+      - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
+        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -36,6 +36,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      # ponytail: source-build stringfish BEFORE dependency setup — packages built
+      # from source during install (e.g. SimDesign) load it at build time and die
+      # on the broken prebuilt binary (oneTBB ABI skew). Drop with the step below.
+      - name: Source-build stringfish (RcppParallel oneTBB ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           extra-packages: any::testthat
@@ -46,7 +52,9 @@ jobs:
       # Rebuild everything LinkingTo RcppParallel from source so it links the installed
       # copy. Drop once upstream binaries re-sync.
       - name: Rebuild RcppParallel-linked packages from source (oneTBB ABI skew)
-        run: Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo"); if (length(bad)) install.packages(bad, type = "source")'
+        run: >-
+          Rscript -e 'bad <- tools::dependsOnPkgs("RcppParallel", dependencies = "LinkingTo");
+          if (length(bad)) install.packages(bad, type = "source")'
 
       - name: Install kaefa package
         run: R CMD INSTALL .

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -41,6 +41,11 @@ jobs:
           extra-packages: any::testthat
           needs: check
 
+      # ponytail: CRAN/RSPM binary skew — stringfish binaries lag RcppParallel's
+      # oneTBB update. Rebuild from source; drop once upstream binaries sync.
+      - name: Rebuild stringfish from source (RcppParallel ABI skew)
+        run: Rscript -e 'install.packages("stringfish", type = "source")'
+
       - name: Install kaefa package
         run: R CMD INSTALL .
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::testthat
           needs: check

--- a/docs/superpowers/plans/2026-07-02-kaefa-2b-krw-sale-readiness.md
+++ b/docs/superpowers/plans/2026-07-02-kaefa-2b-krw-sale-readiness.md
@@ -251,11 +251,11 @@ Guardrails:
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-        - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+        - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
           with:
             use-public-rspm: true
 
-        - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+        - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
           with:
             extra-packages: any::testthat
             needs: check

--- a/docs/traceability/r-lib-actions-v2.12.1.md
+++ b/docs/traceability/r-lib-actions-v2.12.1.md
@@ -23,7 +23,7 @@ runner 또는 package 호환성 회귀가 확인되면 네 action을 함께 마�
 ## 참고문헌
 
 R-lib. (2026, June 23). *r-lib/actions v2.12.1* [Software release notes].
-https://github.com/r-lib/actions/blob/v2-branch/NEWS.md
+https://github.com/r-lib/actions/blob/d3c5be51b12e724e68f33216ca3c148b66d5f0b6/NEWS.md
 
 R-lib. (2026). *Update NEWS for v2.12.1* [Source code commit].
 https://github.com/r-lib/actions/commit/d3c5be51b12e724e68f33216ca3c148b66d5f0b6

--- a/docs/traceability/r-lib-actions-v2.12.1.md
+++ b/docs/traceability/r-lib-actions-v2.12.1.md
@@ -1,0 +1,29 @@
+# r-lib/actions v2.12.1 공급망 추적
+
+## 결정
+
+세 개의 R 검증 workflow에서 사용하는 setup-pandoc, setup-r,
+setup-r-dependencies, check-r-package를 v2.12.1 release commit
+d3c5be51b12e724e68f33216ca3c148b66d5f0b6으로 통일한다. 전체 commit SHA 외의 태그·브랜치·짧은 SHA는
+회귀 계약이 거부한다.
+
+## 호환성 범위
+
+공식 NEWS에 따르면 v2.12는 Node.js 24 전환, public RSPM 기본값 조정,
+아키텍처별 cache key와 Pandoc 3.8.3을 포함하고, v2.12.1은 setup-r URL parser
+경고와 Quarto action을 갱신한다. 현재 workflow의 R matrix, 권한, testthat 실행,
+--no-tests 분리와 scheduled full-suite 계약은 변경하지 않는다.
+
+## 되돌리기
+
+runner 또는 package 호환성 회귀가 확인되면 네 action을 함께 마지막 검증 SHA로
+되돌리고 R-CMD-check, fast/full test suite와 중앙 보안 검사를 같은 헤드에서 다시
+수행한다. 일부 action만 되돌리거나 이동 태그로 우회하지 않는다.
+
+## 참고문헌
+
+R-lib. (2026, June 23). *r-lib/actions v2.12.1* [Software release notes].
+https://github.com/r-lib/actions/blob/v2-branch/NEWS.md
+
+R-lib. (2026). *Update NEWS for v2.12.1* [Source code commit].
+https://github.com/r-lib/actions/commit/d3c5be51b12e724e68f33216ca3c148b66d5f0b6

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -1,0 +1,24 @@
+testthat::test_that("CI r-lib actions use the reviewed v2.12.1 commit", {
+  workflow_paths <- c(
+    testthat::test_path("..", "..", ".github", "workflows", "R-CMD-check.yaml"),
+    testthat::test_path("..", "..", ".github", "workflows", "test-fast.yaml"),
+    testthat::test_path("..", "..", ".github", "workflows", "test-suite.yaml")
+  )
+  workflow_text <- paste(
+    unlist(lapply(workflow_paths, readLines, warn = FALSE)),
+    collapse = "\n"
+  )
+  action_refs <- regmatches(
+    workflow_text,
+    gregexpr(
+      "r-lib/actions/(setup-pandoc|setup-r-dependencies|setup-r|check-r-package)@[^[:space:]#]+",
+      workflow_text,
+      perl = TRUE
+    )
+  )[[1]]
+
+  testthat::expect_gt(length(action_refs), 0)
+  testthat::expect_true(all(
+    sub("^.*@", "", action_refs) == "d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
+  ))
+})

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -41,3 +41,24 @@ testthat::test_that("CI uses exactly the reviewed r-lib action references", {
     )
   }
 })
+
+testthat::test_that("R CMD check refreshes the reviewed dependency cache ABI", {
+  workflow_path <- testthat::test_path(
+    "..", "..", ".github", "workflows", "R-CMD-check.yaml"
+  )
+  workflow_lines <- readLines(workflow_path, warn = FALSE)
+  dependency_step <- grep(
+    "r-lib/actions/setup-r-dependencies@",
+    workflow_lines,
+    fixed = TRUE
+  )
+  testthat::expect_length(dependency_step, 1L)
+  dependency_block <- workflow_lines[
+    dependency_step:min(dependency_step + 8L, length(workflow_lines))
+  ]
+
+  testthat::expect_true(
+    any(grepl("cache-version: '2'", dependency_block, fixed = TRUE)),
+    info = "The reviewed macOS TBB ABI cache refresh must remain explicit"
+  )
+})

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -119,12 +119,22 @@ testthat::test_that("CI rebuilds oneTBB dependents around dependency setup", {
       fixed = TRUE
     )))
     testthat::expect_true(any(grepl(
+      'type = "source"',
+      pre_block,
+      fixed = TRUE
+    )))
+    testthat::expect_true(any(grepl(
       'dependsOnPkgs("RcppParallel", dependencies = "LinkingTo")',
       post_block,
       fixed = TRUE
     )))
     testthat::expect_true(any(grepl(
-      'type = "source"',
+      'install.packages("RcppParallel", type = "source"',
+      post_block,
+      fixed = TRUE
+    )))
+    testthat::expect_true(any(grepl(
+      'install.packages(linked, type = "source"',
       post_block,
       fixed = TRUE
     )))

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -1,24 +1,43 @@
-testthat::test_that("CI r-lib actions use the reviewed v2.12.1 commit", {
+testthat::test_that("CI uses exactly the reviewed r-lib action references", {
+  reviewed_sha <- "d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
   workflow_paths <- c(
     testthat::test_path("..", "..", ".github", "workflows", "R-CMD-check.yaml"),
     testthat::test_path("..", "..", ".github", "workflows", "test-fast.yaml"),
     testthat::test_path("..", "..", ".github", "workflows", "test-suite.yaml")
   )
-  workflow_text <- paste(
-    unlist(lapply(workflow_paths, readLines, warn = FALSE)),
-    collapse = "\n"
+  expected_actions <- list(
+    "R-CMD-check.yaml" = c(
+      "setup-pandoc",
+      "setup-r",
+      "setup-r-dependencies",
+      "check-r-package"
+    ),
+    "test-fast.yaml" = c("setup-r", "setup-r-dependencies"),
+    "test-suite.yaml" = c("setup-r", "setup-r-dependencies")
   )
-  action_refs <- regmatches(
-    workflow_text,
-    gregexpr(
-      "r-lib/actions/(setup-pandoc|setup-r-dependencies|setup-r|check-r-package)@[^[:space:]#]+",
-      workflow_text,
-      perl = TRUE
-    )
-  )[[1]]
+  action_pattern <- paste0(
+    "r-lib/actions/",
+    "(setup-pandoc|setup-r-dependencies|setup-r|check-r-package)",
+    "@[^[:space:]#]+"
+  )
 
-  testthat::expect_gt(length(action_refs), 0)
-  testthat::expect_true(all(
-    sub("^.*@", "", action_refs) == "d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
-  ))
+  for (workflow_path in workflow_paths) {
+    workflow_text <- paste(readLines(workflow_path, warn = FALSE), collapse = "\n")
+    action_refs <- regmatches(
+      workflow_text,
+      gregexpr(action_pattern, workflow_text, perl = TRUE)
+    )[[1]]
+    expected_refs <- paste0(
+      "r-lib/actions/",
+      expected_actions[[basename(workflow_path)]],
+      "@",
+      reviewed_sha
+    )
+
+    testthat::expect_identical(
+      action_refs,
+      expected_refs,
+      info = paste("Unexpected r-lib action set in", basename(workflow_path))
+    )
+  }
 })

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -57,8 +57,16 @@ testthat::test_that("R CMD check refreshes the reviewed dependency cache ABI", {
     dependency_step:min(dependency_step + 8L, length(workflow_lines))
   ]
 
+  active_cache_version_pattern <- paste0(
+    "^[[:space:]]*cache-version:[[:space:]]*",
+    "['\\\"]2['\\\"][[:space:]]*(#.*)?$"
+  )
+  testthat::expect_false(
+    grepl(active_cache_version_pattern, "# cache-version: '2'", perl = TRUE),
+    info = "A commented cache-version example must not satisfy the contract"
+  )
   testthat::expect_true(
-    any(grepl("cache-version: '2'", dependency_block, fixed = TRUE)),
+    any(grepl(active_cache_version_pattern, dependency_block, perl = TRUE)),
     info = "The reviewed macOS TBB ABI cache refresh must remain explicit"
   )
 })

--- a/tests/testthat/test-ci-action-pins.R
+++ b/tests/testthat/test-ci-action-pins.R
@@ -70,3 +70,36 @@ testthat::test_that("R CMD check refreshes the reviewed dependency cache ABI", {
     info = "The reviewed macOS TBB ABI cache refresh must remain explicit"
   )
 })
+
+testthat::test_that("macOS rebuilds TBB-linked packages from source", {
+  workflow_path <- testthat::test_path(
+    "..", "..", ".github", "workflows", "R-CMD-check.yaml"
+  )
+  workflow_lines <- readLines(workflow_path, warn = FALSE)
+  rebuild_step <- grep(
+    "name: Rebuild macOS TBB dependents from source",
+    workflow_lines,
+    fixed = TRUE
+  )
+  testthat::expect_length(rebuild_step, 1L)
+  rebuild_block <- workflow_lines[
+    rebuild_step:min(rebuild_step + 3L, length(workflow_lines))
+  ]
+
+  testthat::expect_true(
+    any(trimws(rebuild_block) == "if: runner.os == 'macOS'"),
+    info = "Native package rebuild must remain scoped to macOS"
+  )
+  testthat::expect_true(
+    any(grepl(
+      'install.packages(c("RcppParallel", "qs2")',
+      rebuild_block,
+      fixed = TRUE
+    )),
+    info = "Both sides of the observed qs2/RcppParallel ABI boundary must rebuild"
+  )
+  testthat::expect_true(
+    any(grepl('type = "source"', rebuild_block, fixed = TRUE)),
+    info = "macOS native packages must compile against the same local TBB ABI"
+  )
+})


### PR DESCRIPTION
## Summary

Consolidate the valid, non-overlapping work from #68 and #69 on the exact current `develop` tip. All `r-lib/actions` components used by the three R validation workflows now resolve to the reviewed v2.12.1 commit `d3c5be51b12e724e68f33216ca3c148b66d5f0b6`.

## Test-first contract

A permanent `testthat` contract enumerates every `setup-pandoc`, `setup-r`, `setup-r-dependencies`, and `check-r-package` reference in the three workflows. The contract rejects the prior mixed v2.11.4/v2.12.1 state, tags, branches, short SHAs, and arbitrary full SHAs; it accepts only the reviewed v2.12.1 commit.

## Preserved behavior

- R release/devel/oldrel and OS matrices;
- read-only workflow permissions;
- package installation and targeted Zh regression test;
- fast test selection and scheduled/manual full suite;
- existing `--no-tests` separation in R CMD check.

## Provenance

The traceability note records the official v2.12.1 NEWS and immutable upstream commit in APA 7 form, including compatibility scope and rollback.

## Supersession

This PR fully preserves the three `setup-r-dependencies` updates from #68 and the `check-r-package` update from #69, while also eliminating the remaining mixed-version `setup-r` references. The protected Dependabot branches could not rebase, and their old OpenCode review failures do not transfer to this current-base head.

## Validation gate

Merge only after this exact head passes R-CMD-check, fast/full test suites, the new action-pin contract, current coverage/docstring evidence, SAST, Security Scan, zero unresolved actionable review threads, and live branch protection. Queued, stale, skipped, or predecessor-head results are not success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * R 검증 및 테스트 워크플로의 자동화 액션을 검토된 릴리스로 업데이트했습니다.
  * 의존성 캐시 버전을 명시해 CI 실행의 일관성을 높였습니다.
  * 병렬 처리 및 문자열 관련 구성 요소를 소스에서 준비하고 연결 패키지를 재빌드해 테스트 안정성을 개선했습니다.
  * CI 액션 참조, 캐시 설정, 의존성 처리 순서를 자동으로 검증합니다.
  * 관련 버전, 호환성 및 복구 절차를 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Current-head review repairs

- Exact per-workflow reference lists now reject a substituted or missing r-lib action, even when every remaining matched action uses the reviewed SHA.
- The completed execution-plan examples use the current reviewed commit.
- The NEWS reference is immutable at the reviewed source commit.
- All three addressed CodeRabbit threads are resolved; exact-head hosted R and security gates remain authoritative.
